### PR TITLE
UIIN-678 receive react via peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-acquisition-units
 
+## 1.1.0 (IN PROGRESS)
+
+* Receive React as a peerDependency (provide by `stripes`). One dep to rule them all. Refs UIIN-678.
+
 ## [1.0.0](https://github.com/folio-org/ui-acquisition-units/tree/v1.0.0) (2019-07-23)
 
 * New app created with stripes-cli

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "moment": "^2.22.2",
     "prop-types": "^15.6.0",
     "query-string": "^6.7.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.5.1",
     "react-intl": "^2.4.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.1.1",


### PR DESCRIPTION
We should only provide react in one place (stripes) and every other
library and app built with stripes should recieve it as a peer. This
reduces the chance of different modules using different minor version of
react with a `~` dependency and pulling multiple versions of it into the
bundle. Multiple versions of React === Bad Things.

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)