### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "redux": "*",
     "redux-form": "*"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "stripes": {
     "actsAs": ["settings"],
     "displayName": "ui-acquisition-units.meta.title",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.