### PR TITLE
UIAC-22 Settings > Acquisitions Units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Settings > Acquisitions Units focus. Refs UIAC-22.
+
 ## [2.2.0](https://github.com/folio-org/ui-acquisition-units/tree/v2.1.0) (2020-10-09)
 [Full Changelog](https://github.com/folio-org/ui-acquisition-units/compare/v2.1.0...v2.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## (IN PROGRESS)
 
+* Settings > Acquisitions Units focus. Refs UIAC-22.
 ## [2.2.0](https://github.com/folio-org/ui-acquisition-units/tree/v2.1.0) (2020-10-09)
 [Full Changelog](https://github.com/folio-org/ui-acquisition-units/compare/v2.1.0...v2.2.0)
 

--- a/src/settings/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList.js
+++ b/src/settings/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { noop } from 'lodash';
+import { useHistory } from 'react-router-dom';
 
 import {
   NavList,
@@ -11,6 +12,8 @@ import {
 } from '@folio/stripes/components';
 
 const AcquisitionUnitsList = ({ acquisitionUnits, getViewPath, getCreatePath }) => {
+  const history = useHistory();
+
   const lastMenu = (
     <Button
       data-test-new-ac-unit
@@ -22,6 +25,10 @@ const AcquisitionUnitsList = ({ acquisitionUnits, getViewPath, getCreatePath }) 
     </Button>
   );
 
+  const goToAcquisitionUnit = useCallback((id) => (
+    history.push(getViewPath(id))
+  ), [getViewPath, history]);
+
   return (
     <Pane
       id="pane-ac-units-list"
@@ -30,10 +37,11 @@ const AcquisitionUnitsList = ({ acquisitionUnits, getViewPath, getCreatePath }) 
       paneTitle={<FormattedMessage id="ui-acquisition-units.meta.title" />}
     >
       <NavList data-test-ac-units-nav-list>
-        {acquisitionUnits.map(acquisitionUnit => (
+        {acquisitionUnits.map((acquisitionUnit, i) => (
           <NavListItem
             key={acquisitionUnit.id}
-            to={getViewPath(acquisitionUnit.id)}
+            onClick={() => goToAcquisitionUnit(acquisitionUnit.id)}
+            autoFocus={i === 0}
           >
             {acquisitionUnit.name}
           </NavListItem>

--- a/test/bigtest/interactors/AcquisitionUnitsList.js
+++ b/test/bigtest/interactors/AcquisitionUnitsList.js
@@ -1,16 +1,28 @@
 import {
+  clickable,
   collection,
   interactor,
   Interactor,
+  is,
   isPresent,
 } from '@bigtest/interactor';
+
+@interactor class AcquisitionUnits {
+  static defaultScope = '[data-test-ac-units-nav-list]';
+  list = collection('[class*=NavListItem---]', {
+    isFocused: is(':focus'),
+    click: clickable(),
+  });
+
+  addLineBtn = new Interactor('[data-test-plugin-find-po-line-button]');
+}
 
 export default interactor(class AcquisitionUnitsListInteractor {
   static defaultScope = '#pane-ac-units-list';
 
   newUnitButton = new Interactor('[data-test-new-ac-unit]');
 
-  units = collection('[class*=NavListItem---]');
+  units = new AcquisitionUnits();
 
   isLoaded = isPresent('[data-test-ac-units-nav-list]');
   whenLoaded() {

--- a/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
+++ b/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
@@ -24,12 +24,16 @@ describe('Acquisition units list', () => {
     expect(acquisitionUnitsList.isPresent).to.be.true;
   });
 
-  it('should render row for each invoice from the response', () => {
-    expect(acquisitionUnitsList.units().length).to.be.equal(UNITS_COUNT);
+  it('should render row for each acquisition unit from the response', () => {
+    expect(acquisitionUnitsList.units.list().length).to.be.equal(UNITS_COUNT);
   });
 
-  it('should display create the new invoice button', () => {
+  it('should display create the new acquisition unit button', () => {
     expect(acquisitionUnitsList.newUnitButton.isPresent).to.be.true;
+  });
+
+  it('should focused on the first acquisition unit', () => {
+    expect(acquisitionUnitsList.units.list(0).isFocused).to.be.true;
   });
 
   describe('new acquisition unit action', () => {
@@ -49,7 +53,7 @@ describe('Acquisition units list', () => {
     const acquisitionUnitDetails = new AcquisitionUnitDetailsInteractor();
 
     beforeEach(async function () {
-      await acquisitionUnitsList.units(0).click();
+      await acquisitionUnitsList.units.list(0).click();
       await acquisitionUnitDetails.whenLoaded();
     });
 

--- a/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
+++ b/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import setupApplication from '../../../helpers/setup-application';
 import AcquisitionUnitsListInteractor from '../../../interactors/AcquisitionUnitsList';
 import AcquisitionUnitEditorInteractor from '../../../interactors/AcquisitionUnitEditor';
+import AcquisitionUnitDetailsInteractor from '../../../interactors/AcquisitionUnitDetails';
 
 const UNITS_COUNT = 15;
 
@@ -41,6 +42,19 @@ describe('Acquisition units list', () => {
 
     it('should open unit editor', () => {
       expect(acquisitionUnitEditor.isVisible).to.be.true;
+    });
+  });
+
+  describe('view acquisition unit deatils', () => {
+    const acquisitionUnitDetails = new AcquisitionUnitDetailsInteractor();
+
+    beforeEach(async function () {
+      await acquisitionUnitsList.units(0).click();
+      await acquisitionUnitDetails.whenLoaded();
+    });
+
+    it('should open unit details', () => {
+      expect(acquisitionUnitDetails.isVisible).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
+++ b/test/bigtest/tests/AcquisitionUnits/AcquisitionUnitsList/AcquisitionUnitsList-test.js
@@ -32,7 +32,7 @@ describe('Acquisition units list', () => {
     expect(acquisitionUnitsList.newUnitButton.isPresent).to.be.true;
   });
 
-  it('should focused on the first acquisition unit', () => {
+  it('should focus on the first acquisition unit', () => {
     expect(acquisitionUnitsList.units.list(0).isFocused).to.be.true;
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
https://issues.folio.org/browse/UIAC-22
If I click on Settings > Acquisition units
Then focus should go to first unit
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
By using the `onClick`-prop for `<NavListItem>` it will render a button that could be autofocused. 
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

![image](https://user-images.githubusercontent.com/43407139/101471249-24aaa300-3958-11eb-832d-67b59cacebc7.png)


#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
