### PR TITLE
UIAC-72 bump optional plugins to compatible versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `Node.js` to `v18` in GitHub Actions. Refs UIAC-70.
 * Introduce new permission to view all acquisition unit settings. Refs UIAC-63.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIAC-71.
+* Bump optional plugins to their `@folio/stripes` `v9` compatible versions. Refs UIAC-72.
 
 ## [4.0.0](https://github.com/folio-org/ui-acquisition-units/tree/v4.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-acquisition-units/compare/v3.3.1...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "redux-form": "^8.3.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^6.3.0"
+    "@folio/plugin-find-user": "^7.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",


### PR DESCRIPTION
Use plugins compatible with the requested version of stripes (v9).

Refs [UIAC-72](https://issues.folio.org/browse/UIAC-72)