### PR TITLE
Remove unused moment dev dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "graphql": "^16.0.0",
     "identity-obj-proxy": "^3.0.0",
     "miragejs": "^0.1.32",
-    "moment": "^2.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",


### PR DESCRIPTION
We are migrating from the `moment` library to `dayjs`. The current module has an unused dev dependency on `moment`. It makes sense to remove from the `package.json`.