### PR TITLE
UIAC-91 Include stripes-core.settings.read in base permission sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.0 (IN PROGRESS)
 
-* Include global `mod-settings` permissions in base permission sets. Refs UIAC-91.
+* Include global `stripes-core.settings.read` permission in base permission sets. Refs UIAC-91.
 * Display patron group name instead of description. Refs UIAC-93.
 * *BREAKING* Refactor external requests to use `react-query`. Refs UIAC-89.
 * Automatically shift focus to the details pane after opening. Refs UIAC-90.

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
         "displayName": "Settings (acquisition units): display list of settings pages",
         "subPermissions": [
           "settings.enabled",
-          "mod-settings.entries.collection.get",
-          "mod-settings.global.read.stripes-core.prefs.manage"
+          "stripes-core.settings.read"
         ],
         "visible": false
       },


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIAC-91

Use a single common permission set instead of separate ones.